### PR TITLE
add conda development instructions

### DIFF
--- a/mavsim_python/README.md
+++ b/mavsim_python/README.md
@@ -54,3 +54,11 @@ workon name_of_env
 
 deactivate
 
+# Create a `conda` environment
+
+Alternatively, if you prefer to use [`anaconda`](https://www.anaconda.com/download) or [`miniconda`](https://docs.conda.io/projects/miniconda/en/latest/) for managing your python environment, you can use the `environment.yml` file in this folder:
+
+```shell
+conda env create -f environment.yml
+conda activate uavbook
+```

--- a/mavsim_python/environment.yml
+++ b/mavsim_python/environment.yml
@@ -1,0 +1,19 @@
+name: uavbook
+channels:
+    - conda-forge
+    - anaconda
+dependencies:
+    - python=3.10
+    - pip
+    - numpy
+    - matplotlib
+    - jupyter
+    - scipy
+    - opencv
+    - pillow
+    - pyqt
+    - pyqtgraph
+    - pyopengl
+    - python-dotenv
+    - pip:
+        - pynput


### PR DESCRIPTION
Conda provides a popular alternative for managing different Python environments.  I recently switched to an M3 MacBook Pro and the only way I could get my environment setup correctly was to use Anaconda so I thought I would share the environment setup instructions that I found.

Thanks for providing this great accompaniment to your book.  I look forward to the publication of the second edition.